### PR TITLE
Implement basic signature verification

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,17 +55,18 @@
     <h3>Payload:</h3>
     <pre id="payload"></pre>
 
-    <!--
     <h3>Signature:</h3>
+    <div class="alerts-banner">
+      <div id="sig-status" class="alert alert-error">NOT VERIFIED</div>
+    </div>
     <pre id="signature"></pre>
-    -->
     <br/>
     <p style="text-align: right">
       By Andrew Brampton (<a href="https://bramp.net">bramp.net</a>)<br/>
 
       <a href="https://github.com/bramp/smart-health-card-scanner">github.com/bramp/smart-health-card-scanner</a><br/>
 
-      Using <a href="https://html5boilerplate.com/">HTML5 Boilerplate</a>, <a href="https://github.com/ianc1/BaseCSS">BaseCSS</a>, <a href="https://github.com/nimiq/qr-scanner">qr-scanner</a>, <a href="https://github.com/brianloveswords/base64url">base64url</a>, <a href="https://github.com/nodeca/pako">pako</a>, and <a href="https://pretty-print-json.js.org/">pretty-print-json</a>
+      Using <a href="https://html5boilerplate.com/">HTML5 Boilerplate</a>, <a href="https://github.com/ianc1/BaseCSS">BaseCSS</a>, <a href="https://github.com/nimiq/qr-scanner">qr-scanner</a>, <a href="https://github.com/brianloveswords/base64url">base64url</a>, <a href="https://github.com/nodeca/pako">pako</a>, <a href="https://github.com/kjur/jsrsasign">jsrsasign</a> and <a href="https://pretty-print-json.js.org/">pretty-print-json</a>
     </p>
   </div>
 

--- a/js/main.js
+++ b/js/main.js
@@ -42,9 +42,9 @@ function update_sig_status(text, isError = false) {
 	sigstatus.classList = isError ? "alert alert-error" : "alert alert-info";
 }
 
-function verify_signature(header, raw, xhr) {
+function verify_signature(header, token, xhr) {
 	if (xhr.status != 200) {
-		update_sig_status('<i class="error">pending</i>Unable to retrieve keys: ' + xhr.statusText);
+		update_sig_status('<i class="error">error</i>Unable to retrieve keys: ' + xhr.statusText);
 		return;
 	}
 
@@ -60,7 +60,7 @@ function verify_signature(header, raw, xhr) {
 		update_sig_status("<i class=\"icon\">error</i>Can't find signing key " + header.kid + " in key manifest");
 		return
 	}
-	const verification = KJUR.jws.JWS.verify(raw, key);
+	const verification = KJUR.jws.JWS.verify(token, key);
 	if (verification) {
 		update_sig_status('<strong><i class="icon">verified</i> VALID SIGNATURE</strong> (key id: ' + header.kid + ") from issuer " + header.iss);
 		return;

--- a/js/main.js
+++ b/js/main.js
@@ -118,10 +118,9 @@ function parse_code(code) {
 	// 		with Reference.reference populated with short resource-scheme URIs (e.g., {"patient": {"reference": "resource:0"}})
 	let payload;
 
+	// TODO Switch to jws.payloadPP over manual b64 if we can get uncompress working
 	if ('zip' in header) {
 		if (header['zip'] == 'DEF') {
-			// Couldn't figure out how to get a valid UInt8Array out of jws.payloadPP
-			// so extract it again
 			payload = inflate_b64(parts[1]);
 		} else {
 			throw 'Unsupported compression ' + header['zip'];

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "base64url": "^3.0.1",
+    "jsrsasign": "^10.4.0",
     "pako": "^2.0.3",
     "pretty-print-json": "^1.0.1",
     "qr-scanner": "^1.2.0"


### PR DESCRIPTION
This is pretty rough and not really well tested (it is hard to find examples to run against it...), but it seems like a useful addition. Doesn't support PKI validation (is anyone using this?).

* Grab keys from the issuer published in the JWS
* Attempt to find the matching kid from the JWS
* Attempt to verify signature against issuer key
* Makes no attempt to make sure the issuer is legitimate, other than in-browser PKI verification.